### PR TITLE
fix(config): add exclusion for top-level tests folder in vitest confi…

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -18,6 +18,7 @@ export default defineConfig(({ mode }) => {
       environment: "jsdom",
       globals: true,
       setupFiles: [],
+      exclude: ["tests", "node_modules", "dist"], // Ignore top-level tests folder
     },
   };
 });


### PR DESCRIPTION
This pull request makes a small configuration change to the Vite test runner setup. The change ensures that the top-level `tests` folder, along with `node_modules` and `dist`, are excluded from test runs. 

([frontend/vite.config.jsR21](diffhunk://#diff-3ab42a14055f455cac92d192b5dfc9b850cd36f1ea3410d1694a602f6d4b83c1R21))…guration