### PR TITLE
Fix lint error caused by useLocation() in Recipe.jsx

### DIFF
--- a/frontend/src/components/Recipe.jsx
+++ b/frontend/src/components/Recipe.jsx
@@ -16,6 +16,7 @@ function calculateDifficulty(timeInMins) {
 }
 
 export default function Recipe({ recipe }) {
+  const location = useLocation(); // information about the URL path, notably `pathname`
   if (!recipe) {
     return <div className="recipe-not-found">Receptet hittades inte.</div>;
   }
@@ -27,7 +28,6 @@ export default function Recipe({ recipe }) {
   // Beräkna svårighetsgrad för det enskilda receptet
   const difficulty = calculateDifficulty(recipe.timeInMins);
 
-  const location = useLocation(); // information about the URL path, notably `pathname`
 
   return (
     <div className="recipe-container">


### PR DESCRIPTION
This PR fixes the lint error message caused by the newly introduced conditional fallback in Recipe.jsx and put useLocation() hook before it. 